### PR TITLE
Fix iFrame rendering issue (Issue #8)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -333,12 +333,12 @@ app.post('/api/screenshot', minuteRateLimiter, hourlyRateLimiter, async (req, re
 
     // Navigate to the URL with a timeout
     await page.goto(url, {
-      waitUntil: 'networkidle2',
+      waitUntil: 'networkidle0',
       timeout: 30000,
     });
 
     // Wait a bit for any animations/lazy loading
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // If a site uses its own theme toggle, try to flip it toward the requested scheme
     if (colorScheme === 'light' || colorScheme === 'dark') {


### PR DESCRIPTION
## Summary
Fixes #8 by changing the Puppeteer navigation wait condition to `networkidle0` (wait for 0 network connections) and increasing the post-load delay to 3000ms.

## Fix Details
- Changed `page.goto` wait condition from `networkidle2` to `networkidle0` to ensure all network resources (including lazy-loaded iframes) are fully loaded.
- Increased the post-navigation delay from 1500ms to 3000ms to give dynamic content (like iframes resizing) more time to settle.

## Test Plan
- Verified that the server still starts and runs locally.
- (Implicit) Capture a screenshot of a site with heavy iframe usage (like hearyago.com) and check if iframes render correctly.