### PR TITLE
Fix: Remove deprecated page.emulateMedia call

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -212,7 +212,6 @@ app.post('/api/screenshot', minuteRateLimiter, hourlyRateLimiter, async (req, re
     // Emulate color scheme preference aggressively so the captured page honors the user's choice
     if (colorScheme === 'light' || colorScheme === 'dark') {
       // 1) Standard media emulation (covers most CSS @media queries)
-      await page.emulateMedia({ colorScheme });
       await page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: colorScheme }]);
 
       // 2) Force color scheme for pages that read matchMedia or the color-scheme meta tag


### PR DESCRIPTION
## Summary
Fixes a `TypeError: page.emulateMedia is not a function` error occurring in production. 

## Fix Details
- Removed the call to `page.emulateMedia({ colorScheme })` which is deprecated/removed in newer Puppeteer versions.
- Relying on `page.emulateMediaFeatures` which is the correct API for setting `prefers-color-scheme`.

## Test Plan
- Verified that `page.emulateMediaFeatures` is the correct method for setting color scheme preferences in Puppeteer documentation.